### PR TITLE
Potential fix for code scanning alert no. 77: Log Injection

### DIFF
--- a/neonpay/web_sync.py
+++ b/neonpay/web_sync.py
@@ -215,8 +215,9 @@ class SyncWebHandler:
                             template_manager.import_template(template_json)
                             applied_count += 1
                         except Exception as e:
+                            sanitized_template_name = str(template_name).replace('\r', '').replace('\n', '')
                             logger.error(
-                                f"Failed to apply template {template_name}: {e}"
+                                f"Failed to apply template {sanitized_template_name}: {e}"
                             )
 
                 return web.json_response(


### PR DESCRIPTION
Potential fix for [https://github.com/neongroupmmc/neonpay/security/code-scanning/77](https://github.com/neongroupmmc/neonpay/security/code-scanning/77)

To fix the problem, we must sanitize any user-controlled data before incorporating it into log messages. Specifically, we need to ensure that `template_name` cannot introduce newlines or other control characters into the logs. The best solution is to clean `template_name` within the logging statement, removing or replacing newline (`\n`, `\r`) characters and any other suspicious characters as needed, preserving the function’s logic but closing the injection risk.

Only `template_name` must be sanitized before it is used in the log message at line 219. The fix can be implemented by adding a line that creates a sanitized version of `template_name`—stripping, for example, newlines—immediately before the logging call, and using this sanitized variable in the log. Since only standard string operations are needed, no additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
